### PR TITLE
don't add example.gif to the npm package tarball

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+example.gif


### PR DESCRIPTION
the example gif is by far the biggest file in the tarball

```
📦  bowling@1.4.0
=== Tarball Contents === 
1.1kB   LICENSE     
896.6kB example.gif 
1.5kB   example.js  
4.2kB   index.js    
9.0kB   test.js     
885B    package.json
2.9kB   CHANGELOG.md
1.8kB   README.md   
371B    .travis.yml 
=== Tarball Details === 
name:          bowling                                 
version:       1.4.0                                   
package size:  384.9 kB                                
unpacked size: 918.3 kB                                
shasum:        913f0f28a72f126953db3cbd5b477a1cb2e01acb
integrity:     sha512-9EqQTAV7SEvif[...]nHULZhbLefmmw==
total files:   9      
```